### PR TITLE
typo in setup-bash-complete

### DIFF
--- a/bin/bash-complete
+++ b/bin/bash-complete
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# ASTRACT: bash-completion magic script
+# ABSTRACT: bash-completion magic script
 package
   bashComplete;
 


### PR DESCRIPTION
Fixed a typo in a comment in the script.
Sorry about the commit message... I must not have seen the text box.
