### PR TITLE
Fix testing issue (see description for details)

### DIFF
--- a/t/10-bash-completion.t
+++ b/t/10-bash-completion.t
@@ -27,6 +27,9 @@ for my $plugin (@plugins) {
   open(my $has_fake_perldoc,       '>', $fake_perldoc);
   open(my $has_fake_bash_complete, '>', $fake_bash_complete);
 
+  chmod 0755, $fake_bash_complete;
+  chmod 0755, $fake_perldoc;
+
   my $script = $bc->setup;
   ok($script, 'Got us a setup script');
 


### PR DESCRIPTION
Currently, if you try and install Bash::Completion 0.005 (or any version other than 0.001, for that matter) on a fresh perl installation, it will fail.  t/10-bash-completion.t fails because it expects the BashComplete plugin to be active, but bash-complete is not present in $PATH, so it isn't active.  You can get around this by installing 0.001 first, but I've included a small patch to fix the test if you don't have Bash::Completion installed in your current perl installation yet.
